### PR TITLE
RouteGuideClient: ensure degrees are in E7 format

### DIFF
--- a/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
+++ b/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
@@ -109,11 +109,11 @@ class RouteGuideClient private constructor(
       }.build(),
       RouteNote.newBuilder().apply {
         message = "Third message"
-        location = point(1, 0)
+        location = point(10000000, 0)
       }.build(),
       RouteNote.newBuilder().apply {
         message = "Fourth message"
-        location = point(1, 1)
+        location = point(10000000, 10000000)
       }.build()
     )
     val requests = requestList.asFlow().onEach { request ->


### PR DESCRIPTION
As indicated in the proto file, "Points are represented as latitude-longitude pairs in the E7 representation".