### PR TITLE
RouteGuideClient: route chat changes

### DIFF
--- a/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
+++ b/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideClient.kt
@@ -98,7 +98,15 @@ class RouteGuideClient private constructor(
 
   fun routeChat() = runBlocking {
     println("*** RouteChat")
-    val requestList = listOf(
+    val requests = generateOutgoingNotes()
+    stub.routeChat(requests).collect { note ->
+      println("Got message \"${note.message}\" at ${note.location.toStr()}")
+    }
+    println("Finished RouteChat")
+  }
+
+  private fun generateOutgoingNotes(): Flow<RouteNote> = flow {
+    val notes = listOf(
       RouteNote.newBuilder().apply {
         message = "First message"
         location = point(0, 0)
@@ -114,20 +122,19 @@ class RouteGuideClient private constructor(
       RouteNote.newBuilder().apply {
         message = "Fourth message"
         location = point(10000000, 10000000)
+      }.build(),
+      RouteNote.newBuilder().apply {
+        message = "Last message"
+        location = point(0, 0)
       }.build()
     )
-    val requests = requestList.asFlow().onEach { request ->
-      println("Sending message \"${request.message}\" at ${request.location.toStr()}")
+    for (note in notes) {
+      println("Sending message \"${note.message}\" at ${note.location.toStr()}")
+      emit(note);
+      delay(500)
     }
-    val rpc = launch {
-      stub.routeChat(requests).collect { note ->
-        println("Got message \"${note.message}\" at ${note.location.toStr()}")
-      }
-      println("Finished RouteChat")
-    }
-
-    rpc.join()
   }
+
 }
 
 fun main(args: Array<String>) {

--- a/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -115,18 +115,17 @@ class RouteGuideServer private constructor(
       }.build()
     }
 
-    override fun routeChat(requests: Flow<RouteNote>): Flow<RouteNote> =
-      flow {
-        requests.collect { note ->
-          val notes: MutableList<RouteNote> = routeNotes.computeIfAbsent(note.location) {
-            Collections.synchronizedList(mutableListOf<RouteNote>())
-          }
-          for (prevNote in notes.toTypedArray()) { // thread-safe snapshot
-            emit(prevNote)
-          }
-          notes += note
+    override fun routeChat(requests: Flow<RouteNote>): Flow<RouteNote> = flow {
+      requests.collect { note ->
+        val notes: MutableList<RouteNote> = routeNotes.computeIfAbsent(note.location) {
+          Collections.synchronizedList(mutableListOf<RouteNote>())
         }
+        for (prevNote in notes.toTypedArray()) { // thread-safe snapshot
+          emit(prevNote)
+        }
+        notes += note
       }
+    }
 
   }
 }


### PR DESCRIPTION
- In the client:
  - Dropped `launch`
  - Created a `generateOutgoingNotes()` helper method that returns a Flow<RouteNote>. 
  - Added a "Last Message" route note at 0,0 to make the output at least a bit more interesting
  - Added a 500 msec delay after a note is emitted on the client side so that we can see the interplay between the client and the server.
- Only reformatting changes in `RouteGuideServer.kt`
