### PR TITLE
fix: separates protoc plugin fat jar from the source jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,13 @@ mainClassName = 'io.grpc.kotlin.generator.GeneratorRunner'
 applicationName = 'grpc-kotlin'
 
 // Generate the jar file to be used by our custom plugin
-jar {
+task protocJar(type: Jar) {
     manifest {
         attributes 'Main-Class': mainClassName
     }
+    baseName = 'protoc-gen-grpc-kotlin'
     from { configurations.compile.collect { it.isDirectory() ? it : zipTree(it) } }
+    with jar
 }
 
 repositories {
@@ -140,6 +142,12 @@ publishing {
             artifactId = 'grpc-kotlin'
             version = '0.1'
             from components.java
+
+            // Add a Fat JAR for the protoc plugin
+            artifact protocJar {
+                classifier "protoc"
+                extension "jar"
+            }
 
             // Generate the artifacts expected by protobuf-gradle-plugin
             artifactForGradlePlugin(it, 'linux', 'aarch_64')

--- a/src/main/dist/protoc-gen-grpc-kotlin
+++ b/src/main/dist/protoc-gen-grpc-kotlin
@@ -23,4 +23,4 @@ JAR_FILENAME=${JAR_FILENAME/-linux-x86_64/}
 JAR_FILENAME=${JAR_FILENAME/-osx-x86_64/}
 
 # Call the jar and pass our args
-java -jar $JAR_FILENAME.jar $1 $2
+java -jar $JAR_FILENAME-protoc.jar $1 $2

--- a/src/main/dist/protoc-gen-grpc-kotlin.bat
+++ b/src/main/dist/protoc-gen-grpc-kotlin.bat
@@ -63,7 +63,7 @@ goto fail
 
 :execute
 setlocal ENABLEDELAYEDEXPANSION
-set JAR_FILENAME=%~n0.jar
+set JAR_FILENAME=%~n0-protoc.jar
 @REM Get jar file name from current filename by stripping os and arch
 call set JAR_FILENAME=%%JAR_FILENAME:-windows-x86_32=%%
 call set JAR_FILENAME=%%JAR_FILENAME:-windows-x86_64=%%


### PR DESCRIPTION
Adds a new jar to the distribution (`grpc-kotlin-[version]-protoc.jar`) which is invoked by protobuf

This will create the following distribution files:

_Files the protoc gradle plugin uses to generate from protos_
 - grpc-kotlin-0.1-linux-aarch_64.exe
 - grpc-kotlin-0.1-linux-x86_32.exe
 - grpc-kotlin-0.1-linux-x86_64.exe
 - grpc-kotlin-0.1-osx-x86_64.exe
 - grpc-kotlin-0.1-windows-x86_32.exe
 - grpc-kotlin-0.1-windows-x86_64.exe

_The FAT JAR wrapped by the above scripts_
 - grpc-kotlin-0.1-protoc.jar

_The library source_
 - grpc-kotlin-0.1.jar
 - grpc-kotlin-0.1.pom