### PR TITLE
switching back to compile for compiler dependencies

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -28,20 +28,20 @@ repositories {
 
 dependencies {
     // Kotlin and Java
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext.coroutinesVersion}"
-    implementation "javax.annotation:javax.annotation-api:1.2"
+    compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext.coroutinesVersion}"
+    compile "javax.annotation:javax.annotation-api:1.2"
 
     // Grpc and Protobuf
-    implementation project(':grpc-kotlin-stub')
-    implementation "com.google.protobuf:protobuf-java:${rootProject.ext.protobufVersion}"
-    implementation "io.grpc:grpc-protobuf:${rootProject.ext.grpcVersion}"
-    implementation "io.grpc:grpc-stub:${rootProject.ext.grpcVersion}"
-    implementation "io.grpc:grpc-netty-shaded:${rootProject.ext.grpcVersion}"
+    compile project(':grpc-kotlin-stub')
+    compile "com.google.protobuf:protobuf-java:${rootProject.ext.protobufVersion}"
+    compile "io.grpc:grpc-protobuf:${rootProject.ext.grpcVersion}"
+    compile "io.grpc:grpc-stub:${rootProject.ext.grpcVersion}"
+    compile "io.grpc:grpc-netty-shaded:${rootProject.ext.grpcVersion}"
 
     // Misc
-    implementation 'com.squareup:kotlinpoet:1.5.0'
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.3.61"
-    implementation "com.google.truth:truth:1.0.1"
+    compile 'com.squareup:kotlinpoet:1.5.0'
+    compile "org.jetbrains.kotlin:kotlin-reflect:1.3.61"
+    compile "com.google.truth:truth:1.0.1"
 
     // Testing
     testImplementation "junit:junit:4.12"


### PR DESCRIPTION
This changes the `protoc-gen-grpc-kotlin` pom to be marked as `<scope>compile</scope>` instead of `<scope>runtime</scope>`