### PR TITLE
Add "/JVM" qualification to link names

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ source, general RPC framework that puts mobile and HTTP/2 first.
 
 For more information, see the following pages:
 
-- [gRPC Kotlin Quick Start][]
-- [gRPC Basics - Kotlin][] tutorial
+- [gRPC Kotlin/JVM Quick Start][]
+- [gRPC Basics - Kotlin/JVM][] tutorial
 - [API Reference][]
 
 [API Reference]: https://grpc.io/grpc-kotlin/grpc-kotlin-stub


### PR DESCRIPTION
Add "/JVM" qualification to links into grpc.io pages, so that the link names match the page titles they are referencing.