### PR TITLE
Make StubFor access via reflection

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/StubFor.kt
+++ b/stub/src/main/java/io/grpc/kotlin/StubFor.kt
@@ -3,5 +3,5 @@ package io.grpc.kotlin
 import kotlin.reflect.KClass
 
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.RUNTIME)
 annotation class StubFor(val value: KClass<*>)


### PR DESCRIPTION
This gRPC-Kotlin project is really awesome. ❤️

Motivation:

Armeria is going to early adopt gRPC-Kotlin by our users' requests.
https://github.com/line/armeria/pull/2669

Armeria gRPC-Java client access `ServiceDescriptor` via reflection.
I think we can access to the original gRPC-Java stub via `StubFor` annotation in coroutine stub.

Modifications:
- Change AnnotationRetention from `BINARY` to `RUNTIME`

Result:
Better interop between Armeria and gRPC-Kotlin 😀