### PR TITLE
Modify bidiStreamingCancelResponsesCancelsRequests test to avoid what…

### DIFF
--- a/stub/src/test/java/io/grpc/kotlin/ClientCallsTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/ClientCallsTest.kt
@@ -694,6 +694,6 @@ class ClientCallsTest: AbstractCallsTest() {
     assertThat(
       ClientCalls.bidiStreamingRpc(channel, bidiStreamingSayHelloMethod, requests).take(2).toList()
     ).containsExactly(helloReply("Hello, Steven"), helloReply("Hello, Garnet")).inOrder()
-    assertThat(cancelled.isCompleted).isTrue()
+    cancelled.join()
   }
 }


### PR DESCRIPTION
… appears to be a race condition causing flakes.