### PR TITLE
Make sure trailers from a StatusException propagate to the client.

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
@@ -253,7 +253,7 @@ object ServerCalls {
         is CancellationException -> Status.CANCELLED.withCause(failure)
         else -> Status.fromThrowable(failure)
       }
-      val trailers = Status.trailersFromThrowable(failure) ?: GrpcMetadata()
+      val trailers = failure?.let { Status.trailersFromThrowable(it) } ?: GrpcMetadata()
       call.close(closeStatus, trailers)
     }
 

--- a/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
@@ -247,12 +247,14 @@ object ServerCalls {
     }
 
     rpcJob.invokeOnCompletion { cause ->
-      val closeStatus = when (val failure = cause ?: rpcJob.doneValue) {
+      val failure = cause ?: rpcJob.doneValue
+      val closeStatus = when (failure) {
         null -> Status.OK
         is CancellationException -> Status.CANCELLED.withCause(failure)
         else -> Status.fromThrowable(failure)
       }
-      call.close(closeStatus, GrpcMetadata())
+      val trailers = Status.trailersFromThrowable(failure) ?: GrpcMetadata()
+      call.close(closeStatus, trailers)
     }
 
     return object: ServerCall.Listener<RequestT>() {


### PR DESCRIPTION
Fixes #68.