### PR TITLE
Add an explicit package for the ProtoFileWithHyphen.  Use the simpler…

### DIFF
--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/ClassSimpleNameTest.kt
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/ClassSimpleNameTest.kt
@@ -35,7 +35,7 @@ class ClassSimpleNameTest {
 
   @Test
   fun asPeer() {
-    val className = ClassName(packageName = "com.google.protobuf", simpleNames = listOf("ByteString"))
+    val className = ClassName("com.google.protobuf", "ByteString")
     val peerName = ClassSimpleName("Peer").asPeer(className)
     assertThat(peerName.packageName).isEqualTo("com.google.protobuf")
     assertThat(peerName.simpleName).isEqualTo("Peer")

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/DescriptorUtilTest.kt
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/DescriptorUtilTest.kt
@@ -17,7 +17,7 @@
 package io.grpc.kotlin.generator.protoc
 
 import com.google.common.truth.Truth.assertThat
-import com.google.protos.testing.ProtoFileWithHyphen
+import io.grpc.testing.ProtoFileWithHyphen
 import io.grpc.kotlin.generator.protoc.testproto.Example3
 import io.grpc.kotlin.generator.protoc.testproto.Example3.ExampleEnum
 import io.grpc.kotlin.generator.protoc.testproto.Example3.ExampleMessage

--- a/compiler/src/test/proto/testing/proto-file-with-hyphen.proto
+++ b/compiler/src/test/proto/testing/proto-file-with-hyphen.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
-package com.google.protos.testing;
+package io.grpc.testing;
+
+option java_package = "io.grpc.testing";
 
 message ProtoFileWithHypen {}


### PR DESCRIPTION
… syntax for ClassName construction, which is backwards-compatible with older KotlinPoet versions.