### PR TITLE
Fix #67.

### DIFF
--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/DescriptorUtil.kt
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/DescriptorUtil.kt
@@ -120,7 +120,8 @@ val FileDescriptorProto.outerClassSimpleName: ClassSimpleName
 
     val foundDuplicate =
       enumTypeList.any { it.enumClassSimpleName == defaultOuterClassName } ||
-        messageTypeList.any { it.anyHaveNameRecursive(defaultOuterClassName) }
+        messageTypeList.any { it.anyHaveNameRecursive(defaultOuterClassName) } ||
+        serviceList.any { it.serviceName.toClassSimpleName() == defaultOuterClassName }
 
     return if (foundDuplicate) {
       defaultOuterClassName.withSuffix("OuterClass")

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/GeneratorConfigTest.kt
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/GeneratorConfigTest.kt
@@ -22,6 +22,7 @@ import com.squareup.kotlinpoet.*
 import io.grpc.kotlin.generator.protoc.testproto.Example3
 import io.grpc.kotlin.generator.protoc.testproto.HasOuterClassNameConflictOuterClass
 import io.grpc.kotlin.generator.protoc.testproto.MyExplicitOuterClassName
+import io.grpc.testing.ServiceNameConflictsWithFileOuterClass
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -177,7 +178,9 @@ class GeneratorConfigTest {
       MyExplicitOuterClassName.getDescriptor() to MyExplicitOuterClassName::class,
       HasOuterClassNameConflictOuterClass.getDescriptor() to
         HasOuterClassNameConflictOuterClass::class,
-      ImplicitJavaPackage.getDescriptor() to ImplicitJavaPackage::class
+      ImplicitJavaPackage.getDescriptor() to ImplicitJavaPackage::class,
+      ServiceNameConflictsWithFileOuterClass.getDescriptor() to
+        ServiceNameConflictsWithFileOuterClass::class
     )
 
   @Test

--- a/compiler/src/test/proto/testing/service_name_conflicts_with_file.proto
+++ b/compiler/src/test/proto/testing/service_name_conflicts_with_file.proto
@@ -1,0 +1,32 @@
+// Copyright 2020 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+syntax = "proto3";
+
+package io.grpc.testing;
+
+option java_package = "io.grpc.testing";
+
+service ServiceNameConflictsWithFile {
+  rpc SayHello(HelloRequest) returns (HelloReply) {}
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
We were checking for conflicting enum or message names, but not service names.