### PR TITLE
Add grpc-kotlin-stub-lite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - echo "errorProne=true" >> $HOME/.gradle/gradle.properties
 
 install:
-  - ./gradlew --stacktrace build publishToMavenLocal
+  - ./gradlew --stacktrace --debug build publishToMavenLocal
   - pushd examples && ./gradlew --stacktrace build && popd
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - echo "errorProne=true" >> $HOME/.gradle/gradle.properties
 
 install:
-  - ./gradlew --stacktrace --debug build publishToMavenLocal
+  - ./gradlew --stacktrace --debug --scan build publishToMavenLocal
   - pushd examples && ./gradlew --stacktrace build && popd
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - echo "errorProne=true" >> $HOME/.gradle/gradle.properties
 
 install:
-  - ./gradlew --stacktrace --debug --scan build publishToMavenLocal
+  - ./gradlew --stacktrace --scan build publishToMavenLocal
   - pushd examples && ./gradlew --stacktrace build && popd
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - echo "errorProne=true" >> $HOME/.gradle/gradle.properties
 
 install:
-  - ./gradlew --stacktrace --scan build publishToMavenLocal
+  - ./gradlew --stacktrace build publishToMavenLocal
   - pushd examples && ./gradlew --stacktrace build && popd
 
 before_script:

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,8 @@ rootProject.name = "grpc-kotlin"
 include 'interop_testing'
 include ":grpc-kotlin-stub"
 project(':grpc-kotlin-stub').projectDir = "$rootDir/stub" as File
+include ":grpc-kotlin-stub-lite"
+project(':grpc-kotlin-stub-lite').projectDir = "$rootDir/stub-lite" as File
 
 if (settings.hasProperty('skipCodegen') && skipCodegen.toBoolean()) {
     println '*** Skipping the build of codegen and compilation of proto files because skipCodegen=true'

--- a/stub-lite/build.gradle
+++ b/stub-lite/build.gradle
@@ -1,0 +1,94 @@
+plugins {
+    id 'com.google.protobuf' version '0.8.11'
+    id 'org.jetbrains.dokka' version '0.10.1'
+
+    // Generate IntelliJ IDEA's .idea & .iml project files
+    // Starting with 0.8.4 of protobuf-gradle-plugin, *.proto and the gen output files are added
+    // to IntelliJ as sources. It is no longer necessary to add them manually to the idea {} block
+    // to jump to definitions from Java and Kotlin files.
+    // For best results, install the Protobuf and Kotlin plugins for IntelliJ.
+    id 'idea'
+
+    // Provide convenience executables for trying out the examples.
+    id 'application'
+    id 'maven-publish'
+}
+
+description = 'gRPC Kotlin: Stub Lite'
+mainClassName = ''
+
+repositories {
+    google()
+    jcenter()
+    mavenCentral()
+    mavenLocal()
+}
+
+dependencies {
+    // Kotlin
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext.coroutinesVersion}"
+
+    // Grpc and Protobuf
+    implementation "io.grpc:grpc-protobuf-lite:${rootProject.ext.grpcVersion}"
+    implementation "io.grpc:grpc-stub:${rootProject.ext.grpcVersion}"
+    implementation "io.grpc:grpc-kotlin-stub:$version"
+
+    // Java
+    implementation "javax.annotation:javax.annotation-api:1.2"
+
+    // Testing
+    testImplementation "junit:junit:4.12"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:5.5.2"
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.3.61"
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.2'
+    testImplementation "com.google.truth.extensions:truth-proto-extension:1.0"
+    testImplementation "io.grpc:grpc-testing:${rootProject.ext.grpcVersion}" // gRCP testing utilities
+}
+
+protobuf {
+    protoc { artifact = "com.google.protobuf:protoc:${rootProject.ext.protobufVersion}" }
+    plugins {
+        // Specify protoc to generate using kotlin protobuf plugin
+        grpc {
+            artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.ext.grpcVersion}"
+        }
+        // Specify protoc to generate using our grpc kotlin plugin
+        grpckt {
+            path = "$rootDir/compiler/build/install/grpc-kotlin-compiler/bin/grpc-kotlin-compiler"
+        }
+    }
+    generateProtoTasks {
+        all().each { task ->
+            if (task.name.startsWith('generateTestProto')) {
+                task.dependsOn { ':grpc-kotlin-compiler:installDist' }
+            }
+            task.plugins {
+                // Generate Java gRPC classes
+                grpc { }
+                // Generate Kotlin gRPC using the custom plugin from library
+                grpckt { }
+            }
+        }
+    }
+}
+
+task javadocJar(type: Jar) {
+    classifier = 'javadoc'
+    from javadoc
+}
+
+task sourcesJar(type: Jar) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+
+            artifact javadocJar
+            artifact sourcesJar
+        }
+    }
+}

--- a/stub-lite/build.gradle
+++ b/stub-lite/build.gradle
@@ -35,41 +35,6 @@ dependencies {
 
     // Java
     implementation "javax.annotation:javax.annotation-api:1.2"
-
-    // Testing
-    testImplementation "junit:junit:4.12"
-    testImplementation "org.junit.jupiter:junit-jupiter-engine:5.5.2"
-    testImplementation "org.jetbrains.kotlin:kotlin-reflect:1.3.61"
-    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.2'
-    testImplementation "com.google.truth.extensions:truth-proto-extension:1.0"
-    testImplementation "io.grpc:grpc-testing:${rootProject.ext.grpcVersion}" // gRCP testing utilities
-}
-
-protobuf {
-    protoc { artifact = "com.google.protobuf:protoc:${rootProject.ext.protobufVersion}" }
-    plugins {
-        // Specify protoc to generate using kotlin protobuf plugin
-        grpc {
-            artifact = "io.grpc:protoc-gen-grpc-java:${rootProject.ext.grpcVersion}"
-        }
-        // Specify protoc to generate using our grpc kotlin plugin
-        grpckt {
-            path = "$rootDir/compiler/build/install/grpc-kotlin-compiler/bin/grpc-kotlin-compiler"
-        }
-    }
-    generateProtoTasks {
-        all().each { task ->
-            if (task.name.startsWith('generateTestProto')) {
-                task.dependsOn { ':grpc-kotlin-compiler:installDist' }
-            }
-            task.plugins {
-                // Generate Java gRPC classes
-                grpc { }
-                // Generate Kotlin gRPC using the custom plugin from library
-                grpckt { }
-            }
-        }
-    }
 }
 
 task javadocJar(type: Jar) {


### PR DESCRIPTION
 - copied `stub/build.gradle` to `stub-lite/build.gradle`
 - Added `stub-lite` as a new package `grpc-kotlin-stub-lite`
 - removed `testImplementation` 
 - removed `protobuf`
 - changed the dependency on `grpc-protobuf` to `grpc-protobuf-lite`

This addresses #80 