### PR TITLE
fix: javadoc generation for grpc-kotlin-stub and grpc-kotlin-stub-lite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
 
     plugins.withId("org.jetbrains.dokka") {
         dokka {
-            outputFormat = 'html'
+            outputFormat = 'javadoc'
             outputDirectory = "$buildDir/dokka"
             configuration {
                 externalDocumentationLink {

--- a/stub-lite/build.gradle
+++ b/stub-lite/build.gradle
@@ -37,23 +37,10 @@ dependencies {
     implementation "javax.annotation:javax.annotation-api:1.2"
 }
 
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
 publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-
-            artifact javadocJar
-            artifact sourcesJar
         }
     }
 }

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -98,7 +98,7 @@ publishing {
         maven(MavenPublication) {
             from components.java
             // Dokka 0.10.1 does not work for JDK 10+
-            if(JavaVersion.current() == JavaVersion.VERSION_1_8){
+            if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
                 artifact javadocJar
                 artifact sourcesJar
             }

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -97,9 +97,11 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-
-            artifact javadocJar
-            artifact sourcesJar
+            // Dokka 0.10.1 does not work for JDK 10+
+            if(JavaVersion.current() == JavaVersion.VERSION_1_8){
+                artifact javadocJar
+                artifact sourcesJar
+            }
         }
     }
 }

--- a/stub/build.gradle
+++ b/stub/build.gradle
@@ -71,9 +71,21 @@ protobuf {
     }
 }
 
-task javadocJar(type: Jar) {
+task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    from javadoc
+    duplicatesStrategy 'exclude'
+    includeEmptyDirs false
+    from javadoc.destinationDir
+}
+
+task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+    outputFormat = 'javadoc'
+    outputDirectory = "$buildDir/javadoc"
+}
+
+javadocJar {
+    dependsOn dokkaJavadoc
+    from dokkaJavadoc.outputDirectory
 }
 
 task sourcesJar(type: Jar) {


### PR DESCRIPTION
Addresses #73 
 - Ensures javadoc is generated for `grpc-kotlin-stub`
 - Removes javadoc generated for `grpc-kotlin-stub-lite`
 - Only publish javadoc when running on Java 8 (see https://github.com/Kotlin/dokka/issues/294)