### PR TITLE
Address #146: fix gradle build issues

### DIFF
--- a/stub/src/test/java/io/grpc/kotlin/CoroutineContextServerInterceptorTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/CoroutineContextServerInterceptorTest.kt
@@ -16,7 +16,6 @@ import kotlin.coroutines.coroutineContext
 import io.grpc.Metadata as GrpcMetadata
 
 /** Tests for [CoroutineContextServerInterceptor]. */
-@RunWith(JUnit4::class) /* inserted by Copybara: */ @com.google.testing.testsize.MediumTest
 class CoroutineContextServerInterceptorTest : AbstractCallsTest() {
   class ArbitraryContextElement(val message: String = "") : CoroutineContext.Element {
     companion object Key : CoroutineContext.Key<ArbitraryContextElement>


### PR DESCRIPTION
Best guess. I assume that a few changes have not been pushed. Unfortunately, I couldn't find the `com.google.testing` artifact, so I just removed it alongside with the junit 4 annotation.

Fixes #146 