### PR TITLE
change server streaming & bidi streaming methods to suspend.

### DIFF
--- a/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt
@@ -182,9 +182,7 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
       "headers" to GrpcMetadata::class
     )
 
-    if (!method.isServerStreaming) {
-      funSpecBuilder.addModifiers(KModifier.SUSPEND)
-    }
+    funSpecBuilder.addModifiers(KModifier.SUSPEND)
 
     funSpecBuilder.addNamedCode(
       """

--- a/compiler/src/main/java/io/grpc/kotlin/generator/GrpcCoroutineServerGenerator.kt
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/GrpcCoroutineServerGenerator.kt
@@ -161,11 +161,11 @@ class GrpcCoroutineServerGenerator(config: GeneratorConfig): ServiceCodeGenerato
       )
 
     val responseType = method.outputType.messageClass()
+    methodSpecBuilder.addModifiers(KModifier.SUSPEND)
     if (method.isServerStreaming) {
       methodSpecBuilder.returns(FLOW.parameterizedBy(responseType))
     } else {
       methodSpecBuilder.returns(responseType)
-      methodSpecBuilder.addModifiers(KModifier.SUSPEND)
     }
 
     methodSpecBuilder.addKdoc(stubKDoc(method, requestParam))

--- a/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
+++ b/examples/src/main/kotlin/io/grpc/examples/routeguide/RouteGuideServer.kt
@@ -85,7 +85,7 @@ class RouteGuideServer private constructor(
                 // No feature was found, return an unnamed feature.
                 features.find { it.location == request } ?: Feature.newBuilder().apply { location = request }.build()
 
-        override fun listFeatures(request: Rectangle): Flow<Feature> =
+        override suspend fun listFeatures(request: Rectangle): Flow<Feature> =
                 features.asFlow().filter { it.exists() && it.location in request }
 
         override suspend fun recordRoute(requests: Flow<Point>): RouteSummary {
@@ -113,7 +113,7 @@ class RouteGuideServer private constructor(
             }.build()
         }
 
-        override fun routeChat(requests: Flow<RouteNote>): Flow<RouteNote> = flow {
+        override suspend fun routeChat(requests: Flow<RouteNote>): Flow<RouteNote> = flow {
             requests.collect { note ->
                 val notes: MutableList<RouteNote> = routeNotes.computeIfAbsent(note.location) {
                     Collections.synchronizedList(mutableListOf<RouteNote>())

--- a/interop_testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.kt
+++ b/interop_testing/src/main/java/io/grpc/testing/integration/TestServiceImpl.kt
@@ -72,7 +72,7 @@ class TestServiceImpl(
       .build()
   }
 
-  override fun streamingOutputCall(
+  override suspend fun streamingOutputCall(
     request: Messages.StreamingOutputCallRequest
   ): Flow<Messages.StreamingOutputCallResponse> {
     return flow {
@@ -103,7 +103,7 @@ class TestServiceImpl(
       }
       .build()
 
-  override fun fullDuplexCall(
+  override suspend fun fullDuplexCall(
     requests: Flow<Messages.StreamingOutputCallRequest>
   ): Flow<Messages.StreamingOutputCallResponse> =
     requests.flatMapConcat {
@@ -116,7 +116,7 @@ class TestServiceImpl(
       streamingOutputCall(it)
     }
 
-  override fun halfDuplexCall(
+  override suspend fun halfDuplexCall(
     requests: Flow<Messages.StreamingOutputCallRequest>
   ): Flow<Messages.StreamingOutputCallResponse> =
     flow {

--- a/stub/src/test/java/io/grpc/kotlin/GeneratedCodeTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/GeneratedCodeTest.kt
@@ -218,7 +218,7 @@ class GeneratedCodeTest : AbstractCallsTest() {
   @Test
   fun simpleServerStreamingRpc() = runBlocking {
     val channel = makeChannel(object : GreeterCoroutineImplBase() {
-      override fun serverStreamSayHello(request: MultiHelloRequest): Flow<HelloReply> {
+      override suspend fun serverStreamSayHello(request: MultiHelloRequest): Flow<HelloReply> {
         return request.nameList.asFlow().map { helloReply("Hello, $it") }
       }
     })
@@ -243,7 +243,7 @@ class GeneratedCodeTest : AbstractCallsTest() {
     val serverReceived = Job()
 
     val channel = makeChannel(object : GreeterCoroutineImplBase() {
-      override fun serverStreamSayHello(request: MultiHelloRequest): Flow<HelloReply> {
+      override suspend fun serverStreamSayHello(request: MultiHelloRequest): Flow<HelloReply> {
         return flow {
           serverReceived.complete()
           suspendUntilCancelled {
@@ -265,7 +265,7 @@ class GeneratedCodeTest : AbstractCallsTest() {
   @Test
   fun bidiPingPong() = runBlocking {
     val channel = makeChannel(object : GreeterCoroutineImplBase() {
-      override fun bidiStreamSayHello(requests: Flow<HelloRequest>): Flow<HelloReply> {
+      override suspend fun bidiStreamSayHello(requests: Flow<HelloRequest>): Flow<HelloReply> {
         return requests.map { helloReply("Hello, ${it.name}") }
       }
     })
@@ -286,7 +286,7 @@ class GeneratedCodeTest : AbstractCallsTest() {
   @Test
   fun bidiStreamingRpcReturnsEarly() = runBlocking {
     val channel = makeChannel(object : GreeterCoroutineImplBase() {
-      override fun bidiStreamSayHello(requests: Flow<HelloRequest>): Flow<HelloReply> {
+      override suspend fun bidiStreamSayHello(requests: Flow<HelloRequest>): Flow<HelloReply> {
         return requests.take(2).map { helloReply("Hello, ${it.name}") }
       }
     })


### PR DESCRIPTION
Currently the server streaming & bidi streaming methods are generated as non suspend function, this cause some issue like the example below.

```kotlin
fun bidiStreamSayHello(requests: Flow<HelloRequest>): Flow<HelloReply> {
    rateLimiterStub.check()   // this is a suspend unary function, how can I call it in a non suspend function?

    // forward the requests to another service
    return anotherServiceStub.bidiStreamSayHello(requests)
        .map { /* do something with the response */ }
}
```