### PR TITLE
Android example: minor updates in prep for Quick start page creation

### DIFF
--- a/examples/android/src/main/kotlin/io/grpc/examples/helloworld/MainActivity.kt
+++ b/examples/android/src/main/kotlin/io/grpc/examples/helloworld/MainActivity.kt
@@ -60,9 +60,9 @@ class MainActivity : AppCompatActivity() {
             try {
                 val request = HelloRequest.newBuilder().setName(nameText.text.toString()).build()
                 val response = greeter.sayHello(request)
-                responseText.text = resources.getString(R.string.server_response, response.message)
+                responseText.text = response.message
             } catch (e: Exception) {
-                responseText.text = resources.getString(R.string.server_error, e.message)
+                responseText.text = e.message
                 e.printStackTrace()
             }
         }

--- a/examples/android/src/main/res/layout/activity_main.xml
+++ b/examples/android/src/main/res/layout/activity_main.xml
@@ -18,11 +18,19 @@
     <Button android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/say_hello"
+        android:text="@string/send_request"
         android:enabled="false"/>
 
+    <TextView android:id="@+id/response_label"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_margin="5dp"
+        android:textSize="18sp"
+        android:text="@string/server_response"/>
+
     <TextView android:id="@+id/response"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_marginHorizontal="5dp"/>
 
 </LinearLayout>

--- a/examples/android/src/main/res/values/strings.xml
+++ b/examples/android/src/main/res/values/strings.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="name_hint">name</string>
-    <string name="say_hello">say hello</string>
+    <string name="name_hint">Name</string>
+    <string name="send_request">Send gRPC Request</string>
     <string name="app_label">gRPC Kotlin Android</string>
-    <string name="server_response">Server says: %s</string>
-    <string name="server_error">Server error: %s</string>
+    <string name="server_response">Server response</string>
 </resources>


### PR DESCRIPTION
Screenshot:

> <img width="400" alt="Screen Shot 2020-10-21 at 12 08 54" src="https://user-images.githubusercontent.com/4140793/96748343-688d1d00-1397-11eb-8872-064fea1c2bdb.png">

Changes:
- Rename button
- Change server response layout. I find that this more clearly separates the server response text (which can be multiline in the case where we "say hello again") from the label "server response".
- Other UI tweaks

These updates are in preparation for the new Kotlin Android Quick start, https://github.com/grpc/grpc.io/issues/468.