### PR TITLE
switch examples to correct stub-lite usage

### DIFF
--- a/examples/stub-android/build.gradle.kts
+++ b/examples/stub-android/build.gradle.kts
@@ -18,16 +18,7 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 
     api("com.google.protobuf:protobuf-javalite:${rootProject.ext["protobufVersion"]}")
-    api("io.grpc:grpc-protobuf-lite:${rootProject.ext["grpcVersion"]}")
-
-    // todo: I think we should be able to just include this:
-    // api("io.grpc:grpc-kotlin-stub-lite:${rootProject.ext["grpcKotlinVersion"]}")
-    // but it doesn't pull transitives correctly
-
-    api("io.grpc:grpc-stub:${rootProject.ext["grpcVersion"]}")
-    api("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}") {
-        exclude("io.grpc", "grpc-protobuf")
-    }
+    api("io.grpc:grpc-kotlin-stub-lite:${rootProject.ext["grpcKotlinVersion"]}")
 }
 
 android {

--- a/examples/stub-lite/build.gradle.kts
+++ b/examples/stub-lite/build.gradle.kts
@@ -17,16 +17,7 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 
     api("com.google.protobuf:protobuf-javalite:${rootProject.ext["protobufVersion"]}")
-    api("io.grpc:grpc-protobuf-lite:${rootProject.ext["grpcVersion"]}")
-
-    // todo: I think we should be able to just include this:
-    // api("io.grpc:grpc-kotlin-stub-lite:${rootProject.ext["grpcKotlinVersion"]}")
-    // but it doesn't pull transitives correctly
-
-    api("io.grpc:grpc-stub:${rootProject.ext["grpcVersion"]}")
-    api("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}") {
-        exclude("io.grpc", "grpc-protobuf")
-    }
+    api("io.grpc:grpc-kotlin-stub-lite:${rootProject.ext["grpcKotlinVersion"]}")
 }
 
 java {

--- a/examples/stub/build.gradle.kts
+++ b/examples/stub/build.gradle.kts
@@ -17,8 +17,6 @@ dependencies {
     implementation("javax.annotation:javax.annotation-api:1.3.2")
 
     api("com.google.protobuf:protobuf-java-util:${rootProject.ext["protobufVersion"]}")
-    api("io.grpc:grpc-stub:${rootProject.ext["grpcVersion"]}")
-    api("io.grpc:grpc-protobuf:${rootProject.ext["grpcVersion"]}")
     api("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}")
 }
 


### PR DESCRIPTION
Depends on #199 and a `0.2.1` release