### PR TITLE
support proto3 optional fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 ext {
-    grpcVersion = '1.29.0' // CURRENT_GRPC_VERSION
-    protobufVersion = '3.11.0'
+    grpcVersion = '1.34.0' // CURRENT_GRPC_VERSION
+    protobufVersion = '3.14.0'
     kotlinVersion = '1.3.61'
     coroutinesVersion = '1.3.3'
     googleauthVersion = '0.20.0'

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/CodeGenerators.kt
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/CodeGenerators.kt
@@ -75,7 +75,8 @@ internal object CodeGenerators {
   inline fun codeGeneratorResponse(build: () -> List<FileSpec>): PluginProtos.CodeGeneratorResponse {
     val builder = PluginProtos.CodeGeneratorResponse.newBuilder()
     try {
-      builder.addAllFile(build().map { toCodeGeneratorResponseFile(it) })
+      builder.setSupportedFeatures(PluginProtos.CodeGeneratorResponse.Feature.FEATURE_PROTO3_OPTIONAL_VALUE.toLong())
+        .addAllFile(build().map { toCodeGeneratorResponseFile(it) })
     } catch (failure: Exception) {
       builder.error = Throwables.getStackTraceAsString(failure)
     }

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
@@ -63,6 +63,7 @@ kt_jvm_test(
         "//compiler/src/test/proto/testing:implicit_java_package_java_proto",
         "//compiler/src/test/proto/testing:service_name_conflicts_with_file_java_proto",
         "//compiler/src/test/proto/testing:service_t_java_proto",
+        "//compiler/src/test/proto/testing:test_proto3_optional_java_proto",
         "@maven//:com_google_truth_truth",
     ],
 )
@@ -85,6 +86,17 @@ kt_jvm_test(
     test_class = "io.grpc.kotlin.generator.protoc.MemberSimpleNameTest",
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
+        "@maven//:com_google_truth_truth",
+    ],
+)
+
+kt_jvm_test(
+    name = "OptionalProto3FieldTest",
+    srcs = ["OptionalProto3FieldTest.kt"],
+    test_class = "io.grpc.kotlin.generator.protoc.OptionalProto3FieldTest",
+    deps = [
+        "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
+        "//compiler/src/test/proto/testing:test_proto3_optional_java_proto",
         "@maven//:com_google_truth_truth",
     ],
 )

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/OptionalProto3FieldTest.kt
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/OptionalProto3FieldTest.kt
@@ -1,0 +1,25 @@
+package io.grpc.kotlin.generator.protoc
+
+import com.google.common.truth.Truth.assertThat
+import io.grpc.testing.TestProto3Optional
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/** Tests for supporting proto3 optional fields. */
+@RunWith(JUnit4::class)
+class OptionalProto3FieldTest {
+
+  @Test
+  fun compileProto3OptionalField() {
+    assertThat(TestProto3Optional.OptionalProto3.getDescriptor().findFieldByName("optional_field"))
+      .isNotNull()
+  }
+
+  @Test
+  fun generateHasOptionalFieldMethod() {
+    assertThat(TestProto3Optional.OptionalProto3::class.java.getMethod("hasOptionalField"))
+      .isNotNull()
+  }
+
+}

--- a/compiler/src/test/proto/testing/BUILD.bazel
+++ b/compiler/src/test/proto/testing/BUILD.bazel
@@ -94,3 +94,14 @@ java_proto_library(
     name = "service_t_java_proto",
     deps = ["service_t_proto"],
 )
+
+proto_library(
+    name = "test_proto3_optional",
+    srcs = ["test_proto3_optional.proto"],
+    strip_import_prefix = "//compiler/src/test/proto",
+)
+
+java_proto_library(
+    name = "test_proto3_optional_java_proto",
+    deps = ["test_proto3_optional"],
+)

--- a/compiler/src/test/proto/testing/test_proto3_optional.proto
+++ b/compiler/src/test/proto/testing/test_proto3_optional.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package io.grpc.testing;
+
+// Currently, java proto compiler supports optional fields only if there is an additional flag
+// --experimental_allow_proto3_optional or the filename (or a directory name) of the proto
+// file contains the string 'test_proto3_optional'
+message OptionalProto3 {
+
+  optional string optional_field = 1;
+
+}

--- a/interop_testing/build.gradle
+++ b/interop_testing/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 }
 
 protobuf {
-    protoc { artifact = 'com.google.protobuf:protoc:3.11.0' }
+    protoc { artifact = 'com.google.protobuf:protoc:3.14.0' }
     plugins {
         // Specify protoc to generate using kotlin protobuf plugin
         grpc {


### PR DESCRIPTION
Currently, java proto3 compiler supports optional fields. But unfortunately, Kotlin grpc compiler fails to compile such fields. There is a small change based on the [docs](https://github.com/protocolbuffers/protobuf/blob/master/docs/implementing_proto3_presence.md). 

As protobuf supports the feature since version 3.13, I updated protobuf and grpc version in the gradle build script. 