### PR TITLE
fix: update to latest grpc version so this runs on ARM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 ext {
-    grpcVersion = '1.34.0' // CURRENT_GRPC_VERSION
+    grpcVersion = '1.36.0' // CURRENT_GRPC_VERSION
     protobufVersion = '3.14.0'
     kotlinVersion = '1.3.61'
     coroutinesVersion = '1.3.3'


### PR DESCRIPTION
Currently the interop tests throw an error on ARM that it cannot find the Conscrypt library.  This is fixed in https://github.com/grpc/grpc-java/commit/b5a0d14da7d04e73c40572c341d2a64ba99db328 but we need to update to the latest version of gRPC to get it.

Related to #229, but that build is not passing for unknown reasons.