### PR TITLE
Fix examples 'unresolved reference: xxxx' bug in idea

### DIFF
--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -18,7 +18,10 @@ allprojects {
         google()
     }
 
-    apply(plugin = "org.jlleitschuh.gradle.ktlint")
+    apply {
+        plugin("org.jlleitschuh.gradle.ktlint")
+        plugin("idea")
+    }
 }
 
 tasks.create("assemble").dependsOn(":server:installDist")


### PR DESCRIPTION
We don't need to add configuration manually in idea #214 