### PR TITLE
Restore metadata support to generated clients

### DIFF
--- a/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt
@@ -31,8 +31,6 @@ import com.squareup.kotlinpoet.TypeVariableName
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import io.grpc.CallOptions
-import io.grpc.Channel as GrpcChannel
-import io.grpc.Metadata as GrpcMetadata
 import io.grpc.MethodDescriptor.MethodType
 import io.grpc.Status
 import io.grpc.StatusException
@@ -50,6 +48,8 @@ import io.grpc.kotlin.generator.protoc.methodName
 import io.grpc.kotlin.generator.protoc.of
 import io.grpc.kotlin.generator.protoc.serviceName
 import kotlinx.coroutines.flow.Flow
+import io.grpc.Channel as GrpcChannel
+import io.grpc.Metadata as GrpcMetadata
 
 /**
  * Logic for generating gRPC stubs for Kotlin.
@@ -62,6 +62,11 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
     private val STREAMING_PARAMETER_NAME = MemberSimpleName("requests")
     private val GRPC_CHANNEL_PARAMETER_NAME = MemberSimpleName("channel")
     private val CALL_OPTIONS_PARAMETER_NAME = MemberSimpleName("callOptions")
+
+    private val HEADERS_PARAMETER: ParameterSpec = ParameterSpec
+      .builder("headers", GrpcMetadata::class)
+      .defaultValue("%T()", GrpcMetadata::class)
+      .build()
 
     val GRPC_CHANNEL_PARAMETER = ParameterSpec.of(GRPC_CHANNEL_PARAMETER_NAME, GrpcChannel::class)
     val CALL_OPTIONS_PARAMETER = ParameterSpec
@@ -172,6 +177,7 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
     val funSpecBuilder =
       funSpecBuilder(name)
         .addParameter(parameter)
+        .addParameter(HEADERS_PARAMETER)
         .returns(returnType)
         .addKdoc(rpcStubKDoc(method, parameter))
 
@@ -179,7 +185,7 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
       "helperMethod" to helperMethod,
       "methodDescriptor" to method.descriptorCode,
       "parameter" to parameter,
-      "headers" to GrpcMetadata::class
+      "headers" to HEADERS_PARAMETER
     )
 
     if (!method.isServerStreaming) {
@@ -193,7 +199,7 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
         %methodDescriptor:L,
         %parameter:N,
         callOptions,
-        %headers:T()
+        %headers:N
       )
       """.trimIndent(),
       codeBlockMap

--- a/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/GrpcClientStubGenerator.kt
@@ -215,7 +215,8 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
       "parameter" to parameter,
       "flow" to Flow::class,
       "status" to Status::class,
-      "statusException" to StatusException::class
+      "statusException" to StatusException::class,
+      "headers" to HEADERS_PARAMETER
     )
 
     val kDocComponents = mutableListOf<String>()
@@ -272,6 +273,10 @@ class GrpcClientStubGenerator(config: GeneratorConfig) : ServiceCodeGenerator(co
       } else {
         "@param %parameter:N The request message to send to the server."
       }
+    )
+
+    kDocComponents.add(
+      "@param %headers:N Metadata to attach to the request.  Most users will not need this."
     )
 
     kDocComponents.add(


### PR DESCRIPTION
Addresses #224.  Users generally shouldn't use this, but it's hard to get any other way, so let's put it back in.