### PR TITLE
Defer writing headers until the first message stanza is sent

### DIFF
--- a/stub/src/test/java/io/grpc/kotlin/ServerCallsTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/ServerCallsTest.kt
@@ -798,4 +798,54 @@ class ServerCallsTest : AbstractCallsTest() {
       ClientCalls.unaryRpc(channel, sayHelloMethod, helloRequest(""))
     ).isEqualTo(helloReply("Hello!"))
   }
+
+  @Test
+  fun serverCallListenerDefersHeaders() = runBlocking {
+    val requestReceived = Job()
+    val responseReleased = Job()
+    val channel = makeChannel(
+      ServerCalls.unaryServerMethodDefinition(context, sayHelloMethod) {
+        requestReceived.complete()
+        responseReleased.join()
+        helloReply("Hello, ${it.name}")
+      }
+    )
+
+    val call = channel.newCall(sayHelloMethod, CallOptions.DEFAULT)
+
+    val headersReceived = Job()
+    val responseReceived = CompletableDeferred<HelloReply>()
+    val closeStatus = CompletableDeferred<Status>()
+
+    call.start(
+      object : ClientCall.Listener<HelloReply>() {
+        override fun onHeaders(headers: Metadata) {
+          headersReceived.complete()
+        }
+
+        override fun onMessage(message: HelloReply) {
+          responseReceived.complete(message)
+        }
+
+        override fun onClose(status: Status, trailers: Metadata) {
+          closeStatus.complete(status)
+        }
+      },
+      Metadata()
+    )
+    call.sendMessage(helloRequest("Bob"))
+    call.request(1)
+    call.halfClose()
+    // wait for the handler to begin
+    requestReceived.join()
+    delay(200)
+    // headers should not have been sent
+    assertThat(headersReceived.isCompleted).isFalse()
+    // release the handler
+    responseReleased.complete()
+    headersReceived.join()
+    assertThat(responseReceived.await()).isEqualTo(helloReply("Hello, Bob"))
+    assertThat(closeStatus.await().code).isEqualTo(Status.Code.OK)
+  }
+
 }


### PR DESCRIPTION
Addresses #272 (see the issue for more background).

This change makes `grpc-kotlin` more consistent with the behaviour of `grpc-java` and `grpc-go`, which don't write the HTTP/2 headers until the first response frame is sent. Current behaviour sends an empty header frame immediately, which can force downstream proxies (namely Envoy) to commit the response, which disables retry behaviour.