### PR TITLE
Move the initial call.request for client streaming calls

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
@@ -223,7 +223,6 @@ object ServerCalls {
         "requests flow can only be collected once"
       }
 
-      call.request(1)
       try {
         for (request in requestsChannel) {
           emit(request)
@@ -255,6 +254,8 @@ object ServerCalls {
       val trailers = failure?.let { Status.trailersFromThrowable(it) } ?: GrpcMetadata()
       mutex.withLock { call.close(closeStatus, trailers) }
     }
+
+    call.request(1)
 
     return object: ServerCall.Listener<RequestT>() {
       var isReceiving = true


### PR DESCRIPTION
Was doing a bit of performance testing of a streaming flow interface, and was finding the request.collect was taking quite some time from the initial invocation of the method. Up to 15ms at times.  The code looks something like this:
```
    fun exampleStream(requests: Flow<Int>): Flow<Int> {
        val start = System.nanoTime()
        return flow<Int> {
            requests.collect { value ->
                val collected = System.nanoTime()
                val thisTime = collected-start
            }
        }
    }
```
The p99 of `thisTime` is what we're seeing vary quite dramatically. I looked at the differences between the flow version and observer version, and found the observer one made a call.request(1) in the `startCall` part, while the flow version only made that initial request after the call to collect.

I did a bit of attempts at perf testing of this locally, and the numbers seem about the same from the client side. In a prod environment, the `thisTime` is slightly better.

