### PR TITLE
Open context val in order to allow overriding

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/AbstractCoroutineServerImpl.kt
+++ b/stub/src/main/java/io/grpc/kotlin/AbstractCoroutineServerImpl.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.EmptyCoroutineContext
  */
 abstract class AbstractCoroutineServerImpl(
   /** The context in which to run server coroutines. */
-  val context: CoroutineContext = EmptyCoroutineContext
+  open val context: CoroutineContext = EmptyCoroutineContext
 ) : BindableService {
   /*
    * Each RPC is executed in its own coroutine scope built from [context].  We could have a parent


### PR DESCRIPTION
This fixes #261 

`val context` is marked as `open` with this PR in order to allow overriding it