### PR TITLE
Load rules_kotlin rules from jvm.bzl

### DIFF
--- a/compiler/src/main/java/io/grpc/kotlin/generator/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/graph/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/graph/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/sort/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/sort/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 licenses(["notice"])
 

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
 
 licenses(["notice"])
 

--- a/examples/client/src/main/kotlin/io/grpc/examples/animals/BUILD.bazel
+++ b/examples/client/src/main/kotlin/io/grpc/examples/animals/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/client/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
+++ b/examples/client/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/client/src/main/kotlin/io/grpc/examples/routeguide/BUILD.bazel
+++ b/examples/client/src/main/kotlin/io/grpc/examples/routeguide/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/native-client/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
+++ b/examples/native-client/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/server/src/main/kotlin/io/grpc/examples/animals/BUILD.bazel
+++ b/examples/server/src/main/kotlin/io/grpc/examples/animals/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/server/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
+++ b/examples/server/src/main/kotlin/io/grpc/examples/helloworld/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/server/src/main/kotlin/io/grpc/examples/routeguide/BUILD.bazel
+++ b/examples/server/src/main/kotlin/io/grpc/examples/routeguide/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_binary")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
 
 licenses(["notice"])
 

--- a/examples/stub/src/main/kotlin/io/grpc/examples/routeguide/BUILD.bazel
+++ b/examples/stub/src/main/kotlin/io/grpc/examples/routeguide/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
 
 def _invoke_generator(ctx, proto_dep, output_dir):

--- a/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
+++ b/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 licenses(["notice"])
 

--- a/stub/src/test/java/io/grpc/kotlin/BUILD.bazel
+++ b/stub/src/test/java/io/grpc/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
 
 licenses(["notice"])
 


### PR DESCRIPTION
As of rules_kotlin v1.5.0-beta-3, its JVM rules should be imported from
jvm.bzl, not kotlin.bzl, to prevent a noisy warning:
https://github.com/bazelbuild/rules_kotlin/blob/v1.5.0-beta-3/kotlin/kotlin.bzl