### PR TITLE
Remove hardcoded references to @bazel

### DIFF
--- a/compiler/src/main/java/io/grpc/kotlin/generator/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/BUILD.bazel
@@ -15,9 +15,9 @@ kt_jvm_library(
         "//stub/src/main/java/io/grpc/kotlin:stub",
         "@com_google_protobuf//:protobuf_java",
         "@io_grpc_grpc_java//core",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_squareup_kotlinpoet",
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@com_google_guava_guava//:com_google_guava_guava",
+        "@com_squareup_kotlinpoet//:com_squareup_kotlinpoet",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_core//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
     ],
 )
 

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
@@ -12,7 +12,7 @@ kt_jvm_library(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/graph",
         "@com_google_protobuf//:protobuf_java",
-        "@maven//:com_google_guava_guava",
-        "@maven//:com_squareup_kotlinpoet",
+        "@com_google_guava_guava//:com_google_guava_guava",
+        "@com_squareup_kotlinpoet//:com_squareup_kotlinpoet",
     ],
 )

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
@@ -11,7 +11,7 @@ kt_jvm_library(
     srcs = glob(["*.kt"]),
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
-        "@maven//:com_google_truth_truth",
-        "@maven//:com_squareup_kotlinpoet",
+        "@com_google_truth_truth//:com_google_truth_truth",
+        "@com_squareup_kotlinpoet//:com_squareup_kotlinpoet",
     ],
 )

--- a/compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/graph/BUILD.bazel
+++ b/compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/graph/BUILD.bazel
@@ -11,6 +11,6 @@ kt_jvm_library(
     srcs = ["TopologicalSortGraph.kt"],
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc/util/sort",
-        "@maven//:com_google_guava_guava",
+        "@com_google_guava_guava//:com_google_guava_guava",
     ],
 )

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/BUILD.bazel
@@ -11,7 +11,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -21,7 +21,7 @@ kt_jvm_test(
     test_class = "io.grpc.kotlin.generator.protoc.ConstantNameTest",
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -32,7 +32,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -47,7 +47,7 @@ kt_jvm_test(
         "//compiler/src/test/proto/testing:has_nested_class_name_conflict_java_proto",
         "//compiler/src/test/proto/testing:has_outer_class_name_conflict_java_proto",
         "//compiler/src/test/proto/testing:proto-file-with-hyphen_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -64,7 +64,7 @@ kt_jvm_test(
         "//compiler/src/test/proto/testing:service_name_conflicts_with_file_java_proto",
         "//compiler/src/test/proto/testing:service_t_java_proto",
         "//compiler/src/test/proto/testing:test_proto3_optional_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -76,7 +76,7 @@ kt_jvm_test(
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/test/proto/testing:example3_java_proto",
         "//compiler/src/test/proto/testing:implicit_java_package_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -86,7 +86,7 @@ kt_jvm_test(
     test_class = "io.grpc.kotlin.generator.protoc.MemberSimpleNameTest",
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -97,7 +97,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/test/proto/testing:test_proto3_optional_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -108,7 +108,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/test/proto/testing:example3_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -119,7 +119,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/test/proto/testing:example3_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -130,7 +130,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/test/proto/testing:example3_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -141,7 +141,7 @@ kt_jvm_test(
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
         "//compiler/src/test/proto/testing:example3_java_proto",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -151,6 +151,6 @@ kt_jvm_test(
     test_class = "io.grpc.kotlin.generator.protoc.ScopeTest",
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )

--- a/compiler/src/test/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
+++ b/compiler/src/test/java/io/grpc/kotlin/generator/protoc/testing/BUILD.bazel
@@ -10,9 +10,9 @@ kt_jvm_test(
     test_class = "io.grpc.kotlin.generator.protoc.testing.DeclarationsSubjectTest",
     deps = [
         "//compiler/src/main/java/io/grpc/kotlin/generator/protoc/testing",
-        "@maven//:com_google_truth_truth",
-        "@maven//:com_squareup_kotlinpoet",
-        "@maven//:junit_junit",
+        "@com_google_truth_truth//:com_google_truth_truth",
+        "@com_squareup_kotlinpoet//:com_squareup_kotlinpoet",
+        "@junit_junit//:junit_junit",
     ],
 )
 

--- a/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
+++ b/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
@@ -16,7 +16,7 @@ kt_jvm_library(
         ":context",
         "@io_grpc_grpc_java//core",
         "@io_grpc_grpc_java//stub",
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_core//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
     ],
 )
 
@@ -25,6 +25,6 @@ kt_jvm_library(
     srcs = ["GrpcContextElement.kt"],
     deps = [
         "@io_grpc_grpc_java//context",
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_core//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
     ],
 )

--- a/stub/src/test/java/io/grpc/kotlin/BUILD.bazel
+++ b/stub/src/test/java/io/grpc/kotlin/BUILD.bazel
@@ -11,7 +11,7 @@ kt_jvm_library(
     deps = [
         "//stub/src/test/proto/helloworld:hello_world_kt_grpc",
         "@io_grpc_grpc_java//testing",
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_debug",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_debug//:org_jetbrains_kotlinx_kotlinx_coroutines_debug",
     ],
 )
 
@@ -22,7 +22,7 @@ kt_jvm_test(
     deps = [
         ":AbstractCallsTest",
         "//stub/src/test/proto/helloworld:hello_world_kt_grpc",
-        "@maven//:com_google_truth_extensions_truth_proto_extension",
+        "@com_google_truth_extensions_truth_proto_extension//:com_google_truth_extensions_truth_proto_extension",
     ],
 )
 
@@ -33,7 +33,7 @@ kt_jvm_test(
     deps = [
         ":AbstractCallsTest",
         "//stub/src/test/proto/helloworld:hello_world_kt_grpc",
-        "@maven//:com_google_truth_truth",
+        "@com_google_truth_truth//:com_google_truth_truth",
     ],
 )
 
@@ -44,7 +44,7 @@ kt_jvm_test(
     deps = [
         ":AbstractCallsTest",
         "//stub/src/test/proto/helloworld:hello_world_kt_grpc",
-        "@maven//:com_google_truth_extensions_truth_proto_extension",
+        "@com_google_truth_extensions_truth_proto_extension//:com_google_truth_extensions_truth_proto_extension",
     ],
 )
 
@@ -55,8 +55,8 @@ kt_jvm_test(
     deps = [
         "//stub/src/main/java/io/grpc/kotlin:context",
         "@io_grpc_grpc_java//core",
-        "@maven//:com_google_truth_truth",
-        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@com_google_truth_truth//:com_google_truth_truth",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_core//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
     ],
 )
 
@@ -67,6 +67,6 @@ kt_jvm_test(
     deps = [
         ":AbstractCallsTest",
         "//stub/src/test/proto/helloworld:hello_world_kt_grpc",
-        "@maven//:com_google_truth_extensions_truth_proto_extension",
+        "@com_google_truth_extensions_truth_proto_extension//:com_google_truth_extensions_truth_proto_extension",
     ],
 )


### PR DESCRIPTION
Fixes #298 by replacing explicit `@maven` repository references in `BUILD.bazel` files with individual repository references.