### PR TITLE
Add kotlinx-coroutines-core-jvm dependency

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -10,8 +10,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 IO_GRPC_GRPC_KOTLIN_ARTIFACTS = [
     "com.google.guava:guava:29.0-jre",
     "com.squareup:kotlinpoet:1.5.0",
-    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5",
-    "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.5",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.3.9",
+    "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.9",
 ]
 
 # For use with maven_install's override_targets.

--- a/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
+++ b/stub/src/main/java/io/grpc/kotlin/BUILD.bazel
@@ -17,6 +17,7 @@ kt_jvm_library(
         "@io_grpc_grpc_java//core",
         "@io_grpc_grpc_java//stub",
         "@org_jetbrains_kotlinx_kotlinx_coroutines_core//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
     ],
 )
 
@@ -26,5 +27,6 @@ kt_jvm_library(
     deps = [
         "@io_grpc_grpc_java//context",
         "@org_jetbrains_kotlinx_kotlinx_coroutines_core//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+        "@org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
     ],
 )


### PR DESCRIPTION
Hi folks,

In my team Bazel project we use grpc-kotlin and we had some compilation issues because some classes from `org.jetbrains.kotlinx:kotlinx-coroutines-core` have been moved into `org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm`.

We tried to change the depedencies into a forked project and it seems to be working fine for us.
This PR contains the changes we made.