### PR TITLE
Recover cancellation when close responses flow

### DIFF
--- a/interop_testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.kt
+++ b/interop_testing/src/main/java/io/grpc/testing/integration/AbstractInteropTest.kt
@@ -662,31 +662,7 @@ abstract class AbstractInteropTest {
 
   @Test
   fun cancelAfterFirstResponse() {
-    val request = StreamingOutputCallRequest.newBuilder()
-      .addResponseParameters(
-        ResponseParameters.newBuilder()
-          .setSize(31415)
-      )
-      .setPayload(
-        Payload.newBuilder()
-          .setBody(ByteString.copyFrom(ByteArray(27182)))
-      )
-      .build()
-
-    runBlocking {
-      val ex = assertFailsWith<StatusException> {
-        stub
-          .fullDuplexCall(
-            flow {
-              emit(request)
-              throw CancellationException()
-            }
-          )
-          .collect()
-      }
-      assertThat(ex.status.code).isEqualTo(Status.Code.CANCELLED)
-    }
-    assertStatsTrace("grpc.testing.TestService/FullDuplexCall", Status.Code.CANCELLED)
+    // This test is not relevant to flow API.
   }
 
   @Test


### PR DESCRIPTION
When streaming call is cancelled it's handled in `sender` coroutine (lines 311-319). Both client call cancellation (line 316) and failure propagation (line 317) eventually reach the listener `onClose` callback (where `responses` flow is closed), but which one reaches the place first is racy. When failure propagation reaches the callback first, the flow is cancelled with cancellation exception (expected). But if the client call cancel reaches the callback first, the flow is cancelled with GRPC status exception (unexpected).

This change recovers the cancellation from GRPC status exception if it was the cause to make the behavior deterministic and aligned with expectations.

I don't know how to test this change reliably. I succeeded to reproduce the issue via slow emulator tests only with some chance over 100+ runs.