### PR TITLE
StatusRuntimeException, StatusException propagate when an error occurs

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/ClientCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ClientCalls.kt
@@ -20,6 +20,7 @@ import io.grpc.CallOptions
 import io.grpc.ClientCall
 import io.grpc.MethodDescriptor
 import io.grpc.Status
+import io.grpc.StatusRuntimeException
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
@@ -293,7 +294,11 @@ object ClientCalls {
 
           override fun onClose(status: Status, trailersMetadata: GrpcMetadata) {
             responses.close(
-              cause = if (status.isOk) null else status.asException(trailersMetadata)
+              cause = when {
+                status.isOk -> null
+                status.cause is StatusRuntimeException -> status.asRuntimeException(trailersMetadata)
+                else -> status.asException(trailersMetadata)
+              }
             )
           }
 

--- a/stub/src/test/java/io/grpc/kotlin/AbstractCallsTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/AbstractCallsTest.kt
@@ -173,6 +173,7 @@ abstract class AbstractCallsTest {
         .forName(serverName)
         .enableRetry()
         .defaultServiceConfig(serviceConfig)
+        .propagateCauseWithStatus(true)
         .run { this as io.grpc.ManagedChannelBuilder<*> } // workaround b/123879662
         .executor(executor)
         .build()

--- a/stub/src/test/java/io/grpc/kotlin/ClientCallsTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/ClientCallsTest.kt
@@ -29,6 +29,7 @@ import io.grpc.Metadata
 import io.grpc.MethodDescriptor
 import io.grpc.Status
 import io.grpc.StatusException
+import io.grpc.StatusRuntimeException
 import io.grpc.examples.helloworld.GreeterGrpc
 import io.grpc.examples.helloworld.HelloReply
 import io.grpc.examples.helloworld.HelloRequest
@@ -220,6 +221,48 @@ class ClientCallsTest: AbstractCallsTest() {
       )
     }
     assertThat(ex.status.code).isEqualTo(Status.Code.UNKNOWN)
+  }
+
+  @Test
+  fun unaryStatusExceptionPropagated() = runBlocking {
+    val serverImpl = object : GreeterGrpc.GreeterImplBase() {
+      override fun sayHello(request: HelloRequest, responseObserver: StreamObserver<HelloReply>) {
+        responseObserver.onError(StatusException(Status.INTERNAL))
+      }
+    }
+
+    channel = makeChannel(serverImpl)
+
+    val ex = assertThrows<StatusException> {
+      ClientCalls.unaryRpc(
+        channel = channel,
+        callOptions = CallOptions.DEFAULT,
+        method = sayHelloMethod,
+        request = helloRequest("Cindy")
+      )
+    }
+    assertThat(ex.status.code).isEqualTo(Status.Code.INTERNAL)
+  }
+
+  @Test
+  fun unaryStatusRuntimeExceptionPropagated() = runBlocking {
+    val serverImpl = object : GreeterGrpc.GreeterImplBase() {
+      override fun sayHello(request: HelloRequest, responseObserver: StreamObserver<HelloReply>) {
+        responseObserver.onError(StatusRuntimeException(Status.INTERNAL.withCause(StatusRuntimeException(Status.INTERNAL))))
+      }
+    }
+
+    channel = makeChannel(serverImpl)
+
+    val ex = assertThrows<StatusRuntimeException> {
+      ClientCalls.unaryRpc(
+        channel = channel,
+        callOptions = CallOptions.DEFAULT,
+        method = sayHelloMethod,
+        request = helloRequest("Cindy")
+      )
+    }
+    assertThat(ex.status.code).isEqualTo(Status.Code.INTERNAL)
   }
 
   @Test


### PR DESCRIPTION
Hi, i am grpc-kotlin user.
current, A StatusException whether it is a StatusException or a StatusRuntimeException.
I think exception is StatusRuntimeException when StatusRuntimeException occurred.
if this intended, you can close this pr.

thank you. 😄 

https://github.com/grpc/grpc-kotlin/issues/347