### PR TITLE
Provide action mnemonics for kt_jvm_proto_library implementation.

### DIFF
--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -200,6 +200,7 @@ def _kt_jvm_proto_library_helper_impl(ctx):
         outputs = [gen_src_dir],
         executable = ctx.executable._protoc,
         arguments = [protoc_args],
+        mnemonic = "KtProtoGenerator",
         progress_message = "Generating kotlin proto extensions for " +
                            ", ".join([
                                str(dep.label)
@@ -216,6 +217,7 @@ def _kt_jvm_proto_library_helper_impl(ctx):
         arguments = [args],
         executable = ctx.executable._zip,
         inputs = [gen_src_dir],
+        mnemonic = "KtProtoSrcJar",
         outputs = [ctx.outputs.srcjar],
     )
 


### PR DESCRIPTION
These names are chosen to mirror the action mnemonics in the kt_jvm_grpc_library implementation.