### PR TITLE
Migrate run command to work on a windows machine

### DIFF
--- a/kt_jvm_grpc.bzl
+++ b/kt_jvm_grpc.bzl
@@ -25,12 +25,12 @@ def _build_srcjar(ctx, proto_dep, input_dir, source_jar):
     args.add("c")
     args.add(source_jar.path)
     args.add_all(depset([input_dir]))
-    ctx.actions.run_shell(
+    ctx.actions.run(
         outputs = [source_jar],
         inputs = [input_dir],
         tools = [ctx.executable._zipper],
         arguments = [args],
-        command = "{zipper} $@".format(zipper = ctx.executable._zipper.path),
+        executable = "{zipper}".format(zipper = ctx.executable._zipper.path),
         mnemonic = "KtGrpcSrcJar",
         progress_message = "Generating Kotlin gRPC srcjar for %s" % proto_dep.label,
     )


### PR DESCRIPTION
running with run_shell on windows results in arguments not being passed properly to zipper. running with `run_shell` calls `bash -c zipper.exe $@ [args]` but does not put quotes around the string passed to bash -c. This means that zipper does not get any arguments passed to it and the step fails. This change makes it so we can run the zipper binary directly and ensures that arguments are passed correctly. It should work on any platform.