### PR TITLE
Open `CoroutineContextServerInterceptor.COROUTINE_CONTEXT_KEY`

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/CoroutineContextServerInterceptor.kt
+++ b/stub/src/main/java/io/grpc/kotlin/CoroutineContextServerInterceptor.kt
@@ -16,9 +16,7 @@ import io.grpc.Context as GrpcContext
  */
 abstract class CoroutineContextServerInterceptor : ServerInterceptor {
   companion object {
-    // This is deliberately kept visibility-restricted; it's intentional that the only way to affect
-    // the CoroutineContext is to extend CoroutineContextServerInterceptor.
-    internal val COROUTINE_CONTEXT_KEY : GrpcContext.Key<CoroutineContext> =
+    val COROUTINE_CONTEXT_KEY : GrpcContext.Key<CoroutineContext> =
       GrpcContext.keyWithDefault("grpc-kotlin-coroutine-context", EmptyCoroutineContext)
 
     private fun GrpcContext.extendCoroutineContext(coroutineContext: CoroutineContext): GrpcContext {


### PR DESCRIPTION
Can we change the relevant part to public?

Although it would be a advanced use, we may want to reference `COROUTINE_CONTEXT_KEY`.

In my product, I use this [issue method](https://github.com/grpc/grpc-kotlin/issues/223#issuecomment-1145153547) to make the interceptor available using the suspend function.
Here, I am using reflection to refer to COROUTINE_CONTEXT_KEY, and I would be happy if it is public.