### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,7 +45,7 @@ jobs:
         ./gradlew :server:HelloWorldServer &
         sleep 30
         OUTPUT=$(./gradlew :client:HelloWorldClient)
-        echo "::set-output name=stdout::${OUTPUT//$'\n'/'%0A'}"
+        echo "stdout=${OUTPUT//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
 
     - name: Test HelloWorld
       if: matrix.java == '11'


### PR DESCRIPTION
## Description

Resolve  #394 

Update `.github/workflows/gradle.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=stdout::${OUTPUT//$'\n'/'%0A'}"
```

**TO-BE**

```yaml
echo "stdout=${OUTPUT//$'\n'/'%0A'}" >> $GITHUB_OUTPUT
```