### PR TITLE
fix(ServerCalls): Ensure failure cause is propagated in Status to interceptors

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
@@ -262,7 +262,7 @@ object ServerCalls {
       val closeStatus = when (failure) {
         null -> Status.OK
         is CancellationException -> Status.CANCELLED.withCause(failure)
-        else -> Status.fromThrowable(failure)
+        else -> Status.fromThrowable(failure).withCause(failure)
       }
       val trailers = failure?.let { Status.trailersFromThrowable(it) } ?: GrpcMetadata()
       mutex.withLock { call.close(closeStatus, trailers) }


### PR DESCRIPTION
This fixes the issue where stack trace logging interceptors fail to log the relevant context when upstream handlers throw a StatusException.

Relates to #299 