### PR TITLE
FIXED: Missing double quotes in compiler docs leading to error.

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -178,7 +178,7 @@ that just runs that `jar`, for example create a file named `protoc-gen-grpc-kotl
 #!/usr/bin/env sh
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-java -jar $DIR/protoc-gen-grpc-kotlin-SOME_VERSION-jdk8.jar "$@
+java -jar $DIR/protoc-gen-grpc-kotlin-SOME_VERSION-jdk8.jar "$@"
 ```
 
 Then make that file executable:


### PR DESCRIPTION
There is a missing double quotes (") in compiler documentation (Manual `protoc` Usage) and when used, produces the following error:

```bash
protoc-gen-grpc-kotlin.sh: line 4: unexpected EOF while looking for matching `"'
protoc-gen-grpc-kotlin.sh: line 5: syntax error: unexpected end of file
```