### PR TITLE
Add regression test capturing need for `withCause` call

### DIFF
--- a/stub/src/test/java/io/grpc/kotlin/ServerCallsTest.kt
+++ b/stub/src/test/java/io/grpc/kotlin/ServerCallsTest.kt
@@ -1168,4 +1168,56 @@ class ServerCallsTest : AbstractCallsTest() {
     assertThat(statusCause!!.stackTraceToString()).contains("internalServerCall")
   }
 
+  @Test
+  fun testPropagateStackTraceForNonStatusExceptionWithStatusExceptionCause() = runBlocking {
+    val thrownStatusCause = CompletableDeferred<Throwable?>()
+
+    val serverImpl = object : GreeterCoroutineImplBase() {
+      override suspend fun sayHello(request: HelloRequest): HelloReply {
+        internalServerCall()
+      }
+
+      private fun internalServerCall(): Nothing {
+        val exception = Exception("causal exception", Status.INTERNAL.asException())
+        thrownStatusCause.complete(exception)
+        throw exception
+      }
+    }
+
+    val receivedStatusCause = CompletableDeferred<Throwable?>()
+
+    val interceptor = object : ServerInterceptor {
+      override fun <ReqT, RespT> interceptCall(
+        call: ServerCall<ReqT, RespT>,
+        requestHeaders: Metadata,
+        next: ServerCallHandler<ReqT, RespT>
+      ): ServerCall.Listener<ReqT> =
+        next.startCall(
+          object : ForwardingServerCall.SimpleForwardingServerCall<ReqT, RespT>(call) {
+            override fun close(status: Status, trailers: Metadata) {
+              receivedStatusCause.complete(status.cause)
+              super.close(status, trailers)
+            }
+          },
+          requestHeaders
+        )
+    }
+
+    val channel = makeChannel(serverImpl, interceptor)
+
+    val stub = GreeterGrpc.newBlockingStub(channel)
+    val clientException = assertThrows<StatusRuntimeException> {
+      stub.sayHello(helloRequest(""))
+    }
+
+    // the exception should not propagate to the client
+    assertThat(clientException.cause).isNull()
+
+    assertThat(clientException.status.code).isEqualTo(Status.Code.INTERNAL)
+    val statusCause = receivedStatusCause.await()
+    // but the exception should propagate to server interceptors, with stack trace intact
+    assertThat(statusCause).isEqualTo(thrownStatusCause.await())
+    assertThat(statusCause!!.stackTraceToString()).contains("internalServerCall")
+  }
+
 }


### PR DESCRIPTION
Something I noticed when writing https://github.com/grpc/grpc-kotlin/pull/456 is that with the new branch capturing Status exceptions, the existing regression test that I modified to throw a non-status exception is no longer sufficient to ensure the stack trace is available to the interceptor. Concretely, `Status.fromThrowable(exception)` will always have `exception` as the cause of the status so long as `exception` is not a Status exception _and has no Status exception in its causal chain_.

This PR adds a test covering that case; without the extra `withCause` call this test will fail.