### PR TITLE
Translate unknown exceptions to UNKNOWN Status

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
@@ -262,7 +262,9 @@ object ServerCalls {
         null -> Status.OK
         is CancellationException -> Status.CANCELLED.withCause(failure)
         is StatusException, is StatusRuntimeException -> Status.fromThrowable(failure)
-        else -> Status.fromThrowable(failure).withCause(failure)
+        else -> Status.UNKNOWN
+          .withDescription("Unknown Exception")
+          .withCause(failure)
       }
       val trailers = failure?.let { Status.trailersFromThrowable(it) } ?: GrpcMetadata()
       mutex.withLock { call.close(closeStatus, trailers) }


### PR DESCRIPTION
When using fromThrowable for unknown exceptions, we are recursively looking for a StatusException or StatusRuntimeException and returning the status of an inner exception. This isn't really the correct behavior because an inner exception that is not caught by the application and not explicitly converted to a StatusException doesn't necessarily translate to the Status that should be returned by the application. 

For example, if ServiceA is calling ServiceB and gets back a `UNAUTHENTICATED` status because ServiceA was not authenticated correctly with ServiceB, it doesn't makes sense for ServiceA to returned `UNAUTHENTICATED` to the client because the client is actually correctly authenticated with ServiceA. It makes more sense to return `Status. UNKNOWN` or even `Status.INTERNAL` in this case. This is just an example of why it's misleading to return the status from an inner StatusException to the client.