### PR TITLE
fix URL constructor deprecation warning

### DIFF
--- a/stub/build.gradle.kts
+++ b/stub/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.google.protobuf.gradle.*
 import org.jetbrains.dokka.gradle.DokkaTask
-import java.net.URL
+import java.net.URI
 
 plugins {
     alias(libs.plugins.dokka)
@@ -80,7 +80,7 @@ tasks.withType<DokkaTask>().configureEach {
         named("main") {
             sourceLink {
                 localDirectory.set(file("src/main/java"))
-                remoteUrl.set(URL("https://github.com/grpc/grpc-kotlin/blob/master/stub/src/main/java"))
+                remoteUrl.set(URI("https://github.com/grpc/grpc-kotlin/blob/master/stub/src/main/java").toURL())
                 remoteLineSuffix.set("#L")
             }
 


### PR DESCRIPTION
fixes the constructor deprecation warning of `java.net.URL` that first appeared in java 20 by replacing it with `java.net.URI.toURL()`

closes #626 