### PR TITLE
Invoke call.close only if call was not cancelled

### DIFF
--- a/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
+++ b/stub/src/main/java/io/grpc/kotlin/ServerCalls.kt
@@ -265,7 +265,9 @@ object ServerCalls {
         else -> Status.fromThrowable(failure).withCause(failure)
       }
       val trailers = failure?.let { Status.trailersFromThrowable(it) } ?: GrpcMetadata()
-      mutex.withLock { call.close(closeStatus, trailers) }
+      mutex.withLock {
+        if (!call.isCancelled) call.close(closeStatus, trailers)
+      }
     }
 
     return object: ServerCall.Listener<RequestT>() {


### PR DESCRIPTION
We experienced an issue with streaming responses. When we have multiple active requests and one of the requests is cancelled by the client, then all other requests are also closed.

It appears that invoking call.close an a cancelled call somehow affects the established http connection which is then closed by the http server.
